### PR TITLE
Fix race condition causing artifacts in invert code

### DIFF
--- a/wallgen.go
+++ b/wallgen.go
@@ -66,7 +66,6 @@ func Flip(input image.Image) image.Image {
 //InvertColors returns a copy of input that has its colors inverted.
 func InvertColors(input image.Image) image.Image {
 
-	var wg sync.WaitGroup
 	//create new image
 	bounds := input.Bounds()
 	newImg := image.NewRGBA(bounds)
@@ -74,23 +73,17 @@ func InvertColors(input image.Image) image.Image {
 	var currentPixelColor color.Color
 	var r, g, b, a uint32
 	for x := 0; x < bounds.Max.X; x++ {
-		x := x
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for y := 0; y < bounds.Max.Y; y++ {
-				r, g, b, a = input.At(x, y).RGBA()
-				currentPixelColor = pixelColor{
-					r: 0xffff - r,
-					g: 0xffff - g,
-					b: 0xffff - b,
-					a: a,
-				}
-				newImg.Set(x, y, currentPixelColor)
+		for y := 0; y < bounds.Max.Y; y++ {
+			r, g, b, a = input.At(x, y).RGBA()
+			currentPixelColor = pixelColor{
+				r: 0xffff - r,
+				g: 0xffff - g,
+				b: 0xffff - b,
+				a: a,
 			}
-		}()
+			newImg.Set(x, y, currentPixelColor)
+		}
 	}
-	wg.Wait()
 
 	return newImg
 }


### PR DESCRIPTION
I noticed some artifacts in the text when I run wallgen on my machine. It looks like a race condition in the InvertColors function. I removed the concurrency and it's gone. It also doesn't seem any slower, so I think the concurrency is probably overkill. See below for before and after. 

Before the change: Notice the artifacts along the left side of the M.

![Before Image](http://imgur.com/VzoerMS.png)

After the M looks clean and smooth:

![After Image](http://imgur.com/IdABbsU.png)
